### PR TITLE
Add updated_at to filter lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,13 +108,6 @@ Shows the URL of the immediate previous page of results.
 
 The pagination links will only be included if they are relevant (eg. there will be no `next` link if you are on the last page.
 
-Updated Since
----------------
-
-Fetching a list of records that have been updated since a specific time is easy. A parameter called `updated_since` should be passed and only the records that have been updated since this time will be retrieved.
-
-This timestamp has to be in UTC if present – e.g. 2014-08-30T18:00:00Z.
-
 Filtering Results
 -----------------
 
@@ -208,6 +201,8 @@ In this example, `q[]` is encoded as `q%5B%5D` so this command works properly in
 * ```%``` is the wildcard symbol for the **wildcard search** operator. You may need to escape it (%25).
 * You can use multiple ```%```'s in a **wildcard search**.
 * The **contains** operator is the same as doing ```%value%``` with the **wildcard search**.
+* You can get only records that have been updated since a certain time by sending a filter for updated_at. Ex: `q=updated_at:>2014-08-30T18:00:00Z`
+
 
 Ordering
 -----------------

--- a/readme.md
+++ b/readme.md
@@ -201,7 +201,7 @@ In this example, `q[]` is encoded as `q%5B%5D` so this command works properly in
 * ```%``` is the wildcard symbol for the **wildcard search** operator. You may need to escape it (%25).
 * You can use multiple ```%```'s in a **wildcard search**.
 * The **contains** operator is the same as doing ```%value%``` with the **wildcard search**.
-* You can get only records that have been updated since a certain time by sending a filter for updated_at. Ex: `q=updated_at:>2014-08-30T18:00:00Z`
+* You can get records that have been updated since a certain time by sending a filter for updated_at. Ex: `q=updated_at:>2014-08-30T18:00:00Z`
 
 
 Ordering

--- a/sections/appointment_types.md
+++ b/sections/appointment_types.md
@@ -73,6 +73,7 @@ Filtering Appointment Types
 ----------------
 
 For any route that returns a set of appointment types, you can filter them by:
-* ```id``` integer
+* ```id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/appointments.md
+++ b/sections/appointments.md
@@ -417,5 +417,6 @@ For any route that returns a set of appointments, you can filter them by:
 * ```id``` Integer
 * ```patient_id``` Integer
 * ```practitioner_id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/businesses.md
+++ b/sections/businesses.md
@@ -110,5 +110,6 @@ Filtering Businesses
 
 You can filter businesses by:
 * ```id``` integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/invoices.md
+++ b/sections/invoices.md
@@ -225,5 +225,6 @@ For any route that returns a set of invoices, you can filter them by:
 * ```patient_id``` Integer
 * ```practitioner_id``` Integer
 * ```status``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/medical_alerts.md
+++ b/sections/medical_alerts.md
@@ -193,5 +193,6 @@ Filtering Medical Alerts
 For any route that returns a set of medical alerts, you can filter them by:
 * ```id``` Integer
 * ```patient_id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/patients.md
+++ b/sections/patients.md
@@ -472,5 +472,6 @@ For any route that returns a set of patients, you can filter them by:
 * ```last_name``` (String)
 * ```email``` (String)
 * ```old_reference_id``` (String)
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/practitioner_reference_numbers.md
+++ b/sections/practitioner_reference_numbers.md
@@ -171,5 +171,6 @@ You can filter practitioner reference numbers by:
 * ```business_id``` Integer
 * ```id``` Integer
 * ```practitioner_id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/practitioners.md
+++ b/sections/practitioners.md
@@ -172,6 +172,7 @@ Filtering Practitioners
 
 For any route that returns a set of practitioners, you can filter them by:
 * ```id``` Integer
+* ```updated_at``` DateTime
 * ```user_id``` Integer
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/products.md
+++ b/sections/products.md
@@ -176,5 +176,6 @@ Filtering Products
 You can filter products by:
 * ```id``` Integer
 * ```tax_id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/stock_adjustments.md
+++ b/sections/stock_adjustments.md
@@ -142,5 +142,6 @@ Filtering Stock Adjustments
 You can filter stock adjustments by:
 * ```id``` integer
 * ```product_id``` integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/taxes.md
+++ b/sections/taxes.md
@@ -142,5 +142,6 @@ Filtering Taxes
 
 You can filter taxes by:
 * ```id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.

--- a/sections/users.md
+++ b/sections/users.md
@@ -110,5 +110,6 @@ Filtering Users
 
 You can filter users by:
 * ```id``` Integer
+* ```updated_at``` DateTime
 
 See [Filtering Results](https://github.com/redguava/cliniko-api#filtering-results) for details on how to apply filters.


### PR DESCRIPTION
And change update since documentation to use a filter instead of its own param. We still support the `updated_since` param, but we will probably remove it in a future version of the API.