### PR TITLE
Updated main readme page with correct appt links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,8 @@ API Resources
 -----------------
 
 * [Appointment Types](https://github.com/redguava/cliniko-api/blob/master/sections/appointment_types.md)
-* [Appointments](https://github.com/redguava/cliniko-api/blob/master/sections/appointments.md)
+* [Appointments (Individual)](https://github.com/redguava/cliniko-api/blob/master/sections/individual_appointments.md)
+* [Appointments (Group)](https://github.com/redguava/cliniko-api/blob/master/sections/group_appointments.md)
 * [Available Times](https://github.com/redguava/cliniko-api/blob/master/sections/available_times.md)
 * [Billable Items](https://github.com/redguava/cliniko-api/blob/master/sections/billable_items.md)
 * [Businesses](https://github.com/redguava/cliniko-api/blob/master/sections/businesses.md)


### PR DESCRIPTION
The old appointments page was linked to, instead of individual and group appointments resources.